### PR TITLE
Correct LocalConnection.domain property

### DIFF
--- a/lib/net/LocalConnection.ts
+++ b/lib/net/LocalConnection.ts
@@ -49,7 +49,7 @@ export class LocalConnection extends EventDispatcher {
 		this._allowedSecureDomains = [];
 
 		// tsc contains a definition for URL that's non-constructible.
-		const url = new (<any>URL)('http://localhost' /*getCurrentABC().env.url*/);
+		const url = new (<any>URL)(window.location.href /*getCurrentABC().env.url*/);
 		this._domain = url.hostname;
 		this._secure = url.protocol === 'https:';
 	}


### PR DESCRIPTION
Instead of using a hardcoded URL, use the current window.location.